### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ tensorflow
 tensorflow_datasets
 tensorflow_hub
 matplotlib
-sklearn
+scikit-learn
 numpy
 requests
 PILLOW


### PR DESCRIPTION
scikit-learn dependency is now called 'scikit-learn' instead of sklearn.